### PR TITLE
feat: Readonly support for attachments

### DIFF
--- a/src/components/calGoogleCalendar.js
+++ b/src/components/calGoogleCalendar.js
@@ -299,7 +299,6 @@ calGoogleCalendar.prototype = {
       case "cache.always":
         return true;
       case "capabilities.timezones.floating.supported":
-      case "capabilities.attachments.supported":
       case "capabilities.priority.supported":
         return false;
       case "capabilities.privacy.values":

--- a/src/modules/gdataUtils.jsm
+++ b/src/modules/gdataUtils.jsm
@@ -866,6 +866,20 @@ function JSONToEvent(aEntry, aCalendar, aDefaultReminders, aReferenceItem, aMeta
     let categories = cal.category.stringToArray(sharedProps["X-MOZ-CATEGORIES"]);
     item.setCategories(categories.length, categories);
 
+    // Attachments
+    if (aEntry.attachments) {
+      for (let attachEntry of aEntry.attachments) {
+        let attachItem = cal.createAttachment();
+        attachItem.uri = Services.io.newURI(attachEntry.fileUrl);
+        attachItem.formatType = attachEntry.mimeType;
+
+        attachItem.setParameter("MANAGED-ID", attachEntry.fileId);
+        attachItem.setParameter("FILENAME", attachEntry.title);
+
+        item.addAttachment(attachItem);
+      }
+    }
+
     // updated (This must be set last!)
     if (aEntry.updated) {
       let updated = cal.dtz.fromRFC3339(aEntry.updated, calendarZone).getInTimezone(cal.dtz.UTC);


### PR DESCRIPTION
This should allow reading, currently untested. Writing seems to be more difficult given the way we currently post the whole event. It doesn't seem like there is a way to update attachments, and just using the attachments json might create duplicate attachments.