### PR TITLE
fix: Pass aData to authFailed for more debugging info

### DIFF
--- a/src/modules/gdataSession.jsm
+++ b/src/modules/gdataSession.jsm
@@ -328,8 +328,8 @@ calGoogleSession.prototype = {
                   callback.onAuthResult(true);
                 }
               },
-              () => {
-                authFailed();
+              (aData) => {
+                authFailed(aData);
                 if (callback) {
                   callback.onAuthResult(false);
                 }


### PR DESCRIPTION
This is a perhaps-naive change.

When attempting to add a new calendar, a person posted a problem on the mailing list where he was getting a "choose calendars" popup with no calendars in it.

His backtrace showed "data: undefined" from the authFailed() method, and this is where the it was being called from.

This might at least shed light on the exact error being produced?