### PR TITLE
Fix broken auth flow 

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -78,7 +78,8 @@
 
     "https://www.googleapis.com/calendar/v3/*",
     "https://www.googleapis.com/tasks/v1/*",
-    "https://accounts.google.com/o/oauth2/approval/v2*"
+    "https://accounts.google.com/o/oauth2/approval/v2*",
+    "http://localhost/*"
   ],
 
   "experiment_apis": {

--- a/test/jest/oauth.test.js
+++ b/test/jest/oauth.test.js
@@ -47,7 +47,7 @@ describe("oauth flow", () => {
 
     expect(browser.webRequest.onBeforeRequest.addListener).toHaveBeenCalled();
     expect(browser.webRequest.onBeforeRequest.addListener.mock.calls[0][1]).toEqual({
-      urls: [oauth.APPROVAL_URL + "*"],
+      urls: [oauth.CALLBACK_URL + "*", oauth.APPROVAL_URL + "*"],
       windowId: "windowId",
     });
 
@@ -56,7 +56,7 @@ describe("oauth flow", () => {
       titlePreface: "preface",
       type: "popup",
       url:
-        "https://accounts.google.com/o/oauth2/v2/auth?client_id=clientId&scope=scope&response_type=code&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob%3Aauto&login_hint=hint&hl=klingon",
+        "https://accounts.google.com/o/oauth2/v2/auth?client_id=clientId&scope=scope&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%2F&login_hint=hint&hl=klingon",
       width: oauth.WINDOW_WIDTH,
       height: oauth.WINDOW_HEIGHT,
     });
@@ -83,7 +83,7 @@ describe("oauth flow", () => {
 
   test("response error", async () => {
     global.browser.webRequest.onBeforeRequest.mockResponse({
-      url: oauth.APPROVAL_URL + "?response=error%3DerrorCode",
+      url: oauth.APPROVAL_URL + "?error=errorCode",
     });
 
     await expect(oauth.login({})).rejects.toEqual({ error: "errorCode" });


### PR DESCRIPTION
This PR:
- Replaces oob redirect uri with `http://localhost`.
- Updates code that handles url params in the response according to [oauth google docs](https://developers.google.com/identity/protocols/oauth2/web-server#handlingresponse):
  - Replace url param `approvalCode` with `code`.
  - Get error message directly from `error` param.
- Updates manifest to include permission for `http://localhost`.