### PR TITLE
Change method to PATCH for events not organized by yourself

### DIFF
--- a/src/legacy/modules/gdataCalendar.jsm
+++ b/src/legacy/modules/gdataCalendar.jsm
@@ -493,7 +493,7 @@ class calGoogleCalendar extends cal.provider.BaseClass {
         // Updating invitations often causes a forbidden error because
         // some parts are not writable. Using PATCH ignores anything
         // that isn't allowed.
-        if (cal.itip.isInvitation(aNewItem)) {
+        if (cal.itip.isInvitation(aNewItem) || aNewItem.organizer.id != "mailto:" + this.mCalendarName) {
           request.type = request.PATCH;
         }
 


### PR DESCRIPTION
This avoids 403 forbidden messages when dismissing notifications on events that you are not the organizer for.

Fixes #3 