### PR TITLE
Mapping colors to categories (proof-of-concept)

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -181,7 +181,7 @@
     "message": "Force use of plain text in event descriptions"
   },
   "settings.enableColors": {
-    "message": "Enable support for event colors (experimental; calendars must be unsubscribed, Thunderbird restarted (?), and the calendars resubscribed)"
+    "message": "Enable support for event colors (experimental; enabling/disabling reloads all calendars)"
   },
 
   "eventdialog.conferenceLabel": {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -165,7 +165,7 @@
   },
 
   "settings.warning": {
-    "message": "These settings are will allow you to make use of email scheduling via Google Calendar, but there have also been reports about extraneous notification emails being sent. Please test with a small meeting first."
+    "message": "The settings below allow you to make use of email scheduling via Google Calendar, but there have also been reports about extraneous notification emails being sent. Please test with a small meeting first."
   },
 
   "settings.enableEmailInvitations": {
@@ -179,6 +179,9 @@
   },
   "settings.forcePlainText": {
     "message": "Force use of plain text in event descriptions"
+  },
+  "settings.enableColors": {
+    "message": "Enable support for event colors (experimental; calendars must be unsubscribed, Thunderbird restarted (?), and the calendars resubscribed)"
   },
 
   "eventdialog.conferenceLabel": {

--- a/src/api/gdata.js
+++ b/src/api/gdata.js
@@ -57,6 +57,18 @@ this.gdata = class extends ExtensionAPI {
       let gdataUI = ChromeUtils.import("resource://gdata-provider/legacy/modules/gdataUI.jsm");
       gdataUI.register();
     });
+
+    const google_colors = ["#000", "#7986CB", "#33B679", "#8E24AA", "#E67C73", "#F6BF26",
+                    "#F4511E", "#039BE5", "#616161", "#3F51B5", "#0B8043", "#D50000"];
+    let calendar_categories = Services.prefs.getStringPref("calendar.categories.names");
+    if (!calendar_categories.includes("Google Color 01")) {
+      for (let i=1; i<=11; i++) {
+        let padded_index = i.toString().padStart(2,'0');
+        calendar_categories += ",Google Color " + padded_index;
+        Services.prefs.setStringPref("calendar.category.color.google_color_" + padded_index, google_colors[i]);
+      }
+      Services.prefs.setStringPref("calendar.categories.names", calendar_categories);
+    }
   }
 
   onShutdown(isAppShutdown) {

--- a/src/api/gdata.js
+++ b/src/api/gdata.js
@@ -57,18 +57,6 @@ this.gdata = class extends ExtensionAPI {
       let gdataUI = ChromeUtils.import("resource://gdata-provider/legacy/modules/gdataUI.jsm");
       gdataUI.register();
     });
-
-    const google_colors = ["#000", "#7986CB", "#33B679", "#8E24AA", "#E67C73", "#F6BF26",
-                    "#F4511E", "#039BE5", "#616161", "#3F51B5", "#0B8043", "#D50000"];
-    let calendar_categories = Services.prefs.getStringPref("calendar.categories.names");
-    if (!calendar_categories.includes("Google Color 01")) {
-      for (let i=1; i<=11; i++) {
-        let padded_index = i.toString().padStart(2,'0');
-        calendar_categories += ",Google Color " + padded_index;
-        Services.prefs.setStringPref("calendar.category.color.google_color_" + padded_index, google_colors[i]);
-      }
-      Services.prefs.setStringPref("calendar.categories.names", calendar_categories);
-    }
   }
 
   onShutdown(isAppShutdown) {

--- a/src/legacy/modules/gdataUI.jsm
+++ b/src/legacy/modules/gdataUI.jsm
@@ -7,6 +7,9 @@ var EXPORTED_SYMBOLS = ["register", "unregister", "recordModule", "recordWindow"
 
 var { ExtensionSupport } = ChromeUtils.import("resource:///modules/ExtensionSupport.jsm");
 
+const Services =
+  globalThis.Services || ChromeUtils.import("resource://gre/modules/Services.jsm").Services; // Thunderbird 103 compat
+
 var unregisterIds = [];
 var unregisterModules = new Set();
 var closeWindows = new Set();
@@ -67,9 +70,23 @@ function register() {
       checkMigrateCalendars(window);
     },
   });
+
+  let { doEnableColors, getMessenger } = ChromeUtils.import(
+    "resource://gdata-provider/legacy/modules/gdataUtils.jsm"
+  );
+    
+  let enableColors = getMessenger().gdataSyncPrefs.get("settings.enableColors", false);
+  if (enableColors) {
+    doEnableColors();
+  }
 }
 
 function unregister() {
+  let { doDisableColors } = ChromeUtils.import(
+    "resource://gdata-provider/legacy/modules/gdataUtils.jsm"
+  );
+  doDisableColors();
+
   for (let id of unregisterIds) {
     ExtensionSupport.unregisterWindowListener(id);
     Cu.unload(`resource://gdata-provider/legacy/modules/ui/${id}.jsm`);

--- a/src/legacy/modules/gdataUI.jsm
+++ b/src/legacy/modules/gdataUI.jsm
@@ -71,11 +71,21 @@ function register() {
     },
   });
 
-  let { doEnableColors, getMessenger } = ChromeUtils.import(
+  let { doEnableColors, doDisableColors, getMessenger } = ChromeUtils.import(
     "resource://gdata-provider/legacy/modules/gdataUtils.jsm"
   );
-    
-  let enableColors = getMessenger().gdataSyncPrefs.get("settings.enableColors", false);
+
+  let messenger = getMessenger();
+  messenger.storage.onChanged.addListener((settings, _target) => {
+    if ("settings.enableColors" in settings) {
+      if (settings["settings.enableColors"].newValue) {
+        doEnableColors();
+      } else {
+        doDisableColors();
+      }
+    }
+  });
+  let enableColors = messenger.gdataSyncPrefs.get("settings.enableColors", false);
   if (enableColors) {
     doEnableColors();
   }

--- a/src/legacy/modules/gdataUtils.jsm
+++ b/src/legacy/modules/gdataUtils.jsm
@@ -55,6 +55,7 @@ var EXPORTED_SYMBOLS = [
   "spinEventLoop",
   "doEnableColors",
   "doDisableColors",
+  "flushCache",
   "getMessenger",
 ];
 
@@ -1523,6 +1524,18 @@ function doDisableColors() {
   let calendarCategories = Services.prefs.getStringPref("calendar.categories.names");
   calendarCategories = calendarCategories.replaceAll(/,Google\sColor\s\d\d/g, "")
   Services.prefs.setStringPref("calendar.categories.names", calendarCategories);
+}
+
+/**
+ * Deletes the local Google calendar cache and reloads all Google calendars from the source.
+ */
+function flushCache() {
+  let cals = cal.manager.wrappedJSObject.getCalendars();
+  for (let calendar of cals) {
+    if (calendar.type == "gdata") {
+      calendar.mUncachedCalendar.resetLog();
+    }
+  }
 }
 
 class SyncPrefs {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -4,6 +4,18 @@
     <meta charset="utf-8">
   </head>
   <body>
+    <div class="browser-style">
+      <input type="checkbox" id="enableAttendees"/>
+      <label for="enableAttendees" data-l10n-id="settings.enableAttendees"/>
+    </div>
+    <div class="browser-style">
+      <input type="checkbox" id="forcePlainText"/>
+      <label for="forcePlainText" data-l10n-id="settings.forcePlainText"/>
+    </div>
+    <div class="browser-style">
+      <input type="checkbox" id="enableColors"/>
+      <label for="enableColors" data-l10n-id="settings.enableColors"/>
+    </div>
     <p data-l10n-id="settings.warning"></p>
     <div class="browser-style">
       <input type="checkbox" id="enableEmailInvitations"/>
@@ -12,14 +24,6 @@
     <div class="browser-style">
       <input type="checkbox" id="sendEventNotifications"/>
       <label for="sendEventNotifications" data-l10n-id="settings.sendEventNotifications"/>
-    </div>
-    <div class="browser-style">
-      <input type="checkbox" id="enableAttendees"/>
-      <label for="enableAttendees" data-l10n-id="settings.enableAttendees"/>
-    </div>
-    <div class="browser-style">
-      <input type="checkbox" id="forcePlainText"/>
-      <label for="forcePlainText" data-l10n-id="settings.forcePlainText"/>
     </div>
     <script src="options.js"></script>
   </body>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -17,6 +17,7 @@ for (let node of document.querySelectorAll("[data-l10n-id]")) {
     "settings.sendEventNotifications": false,
     "settings.enableAttendees": false,
     "settings.forcePlainText": false,
+    "settings.enableColors": false,
   });
 
   for (let [id, value] of Object.entries(prefs)) {


### PR DESCRIPTION
The single biggest issue I had with Google Calendar and Thunderbird was the lack of support for event colors. In this proof-of-concept I approach this issue the following way:
* I create Thunderbird categories "Google Color 01", "Google Color 02", ..., "Google Color 11" and assign these the respective colors from Google.
* When downloading an event that has a color, it is assigned the respective Thunderbird group.
* When uploading an event that has one of the "Google Color x" categories set, this category is removed and the Google color set instead.

This allows users on Thunderbird to both see and change the colors of events.

### Future
If you are interested in integrating this code, please tell me which features you would like to see. Some ideas of mine:
* This feature should be opt-in so users don't get 11 new categories they don't want.
* I don't think the new categories can be automatically removed when the addon is uninstalled. This feature is not strictly necessary in my eyes, but if you have any ideas how to do that I'd love to hear them.
* I have written a `userChrome.css` to make the color box more apparent and get the layout to be more in line with Google, which could become another opt-in feature:
![css-example](https://user-images.githubusercontent.com/17198703/228266224-cc902ef9-db16-4cf5-af5c-f918b6d7e564.png)
  <details>
  <summary>
  Click to expand css code
  </summary>

  ```css
  @namespace html url("http://www.w3.org/1999/xhtml");
  .calendar-category-box {
    width: 100% !important;
    inset-block: 0px !important;
    inset-inline-start: 5px !important;
    inset-inline-end: 0px !important;
  }
  
  .item-time-label {
    color: white;
    font-weight: 700 !important;
  }
  
  .event-name-label {
    color: white;
    font-weight: 600 !important;
  }
  
  calendar-month-day-box-item[selected="true"] > .item-time-label {
    color: #000 !important;
    font-weight: 750 !important;
  }
  
  calendar-month-day-box-item[selected="true"] > .event-name-label {
    color: #000 !important;
    font-weight: 650 !important;
  }
  ```
</details>
Any thoughts would be appreciated.