### PR TITLE
Use Services global variable if possible

### DIFF
--- a/src/experiments/calendar/parent/ext-calendar-calendars.js
+++ b/src/experiments/calendar/parent/ext-calendar-calendars.js
@@ -2,13 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/* global Services */
+
 var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
 var { ExtensionUtils } = ChromeUtils.import("resource://gre/modules/ExtensionUtils.jsm");
 
 var { ExtensionAPI, EventManager } = ExtensionCommon;
 var { ExtensionError } = ExtensionUtils;
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 var { cal } = ChromeUtils.import("resource:///modules/calendar/calUtils.jsm");
 
 this.calendar_calendars = class extends ExtensionAPI {

--- a/src/experiments/calendar/parent/ext-calendar-provider.js
+++ b/src/experiments/calendar/parent/ext-calendar-provider.js
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/* global Services */
+
 var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 var { cal } = ChromeUtils.import("resource:///modules/calendar/calUtils.jsm");
 
 var { ExtensionAPI, EventManager } = ExtensionCommon;

--- a/src/experiments/gdata/ext-gdata.js
+++ b/src/experiments/gdata/ext-gdata.js
@@ -3,8 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  * Portions Copyright (C) Philipp Kewisch */
 
+/* global Services */
+
 var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 var { cal } = ChromeUtils.import("resource:///modules/calendar/calUtils.jsm");
 
 var { ExtensionAPI } = ExtensionCommon;

--- a/src/legacy/modules/ui/gdata-calendar-creation.jsm
+++ b/src/legacy/modules/ui/gdata-calendar-creation.jsm
@@ -9,7 +9,9 @@ function gdataInitUI(window, document) {
     "ui/gdata-calendar-creation.jsm"
   );
 
-  const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+  const Services = globalThis.Services || ChromeUtils.import(
+    "resource://gre/modules/Services.jsm"
+  ).Services;
   const { cal } = ChromeUtils.import("resource:///modules/calendar/calUtils.jsm");
   const { getGoogleSessionManager } = ChromeUtils.import(
     "resource://gdata-provider/legacy/modules/gdataSession.jsm"

--- a/test/xpcshell/test_gdata_provider.js
+++ b/test/xpcshell/test_gdata_provider.js
@@ -19,7 +19,9 @@
 
 var { HttpServer } = ChromeUtils.import("resource://testing-common/httpd.js");
 var { NetUtil } = ChromeUtils.import("resource://gre/modules/NetUtil.jsm");
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 
 Services.prefs.setBoolPref("javascript.options.showInConsole", true);
 Services.prefs.setBoolPref("browser.dom.window.dump.enabled", true);


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and those code doesn't have to import Services.jsm if the strict_min_version is 91.

Also Services variable is available in all system globals from version 104 https://bugzilla.mozilla.org/show_bug.cgi?id=1667455 , and those code doesn't have to import Services.jsm for recent versions.