### PR TITLE
chore: Compatibility and version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gdata-provider",
-  "version": "115.3.0",
+  "version": "115.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gdata-provider",
-      "version": "115.2.0",
+      "version": "115.4.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "@commitlint/cli": "^13.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gdata-provider",
   "description": "Provider for Google Calendar",
-  "version": "115.3.0",
+  "version": "115.4.0",
   "private": true,
   "author": "Philipp Kewisch <mozilla@kewis.ch>",
   "license": "MPL-2.0",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "115.3.0",
+  "version": "115.4.0",
   "author": "Philipp Kewisch",
   "homepage_url": "https://addons.thunderbird.net/thunderbird/addon/provider-for-google-calendar/",
   "default_locale": "en",
@@ -10,7 +10,7 @@
     "gecko": {
       "id": "{a62ef8ec-5fdc-40c2-873c-223b8a6925cc}",
       "strict_min_version": "102.0",
-      "strict_max_version": "127.*"
+      "strict_max_version": "128.*"
     }
   },
   "icons": {


### PR DESCRIPTION
As reported in #772, the add-on seems to work fine with TB 128 (which I can confirm).