### PR TITLE
Improve OAuth2 invalid refresh token handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "conventional-changelog": "^6.0.0",
         "conventional-changelog-cli": "^5.0.0",
+        "cross-env": "^7.0.3",
         "eslint": "^9.22.0",
         "eslint-plugin-jest": "^28.11.0",
         "ical.js": "^2.1.0",
@@ -3500,6 +3501,25 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-fetch": {
       "version": "3.1.8",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "verbose": true
   },
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "build": "rm -f dist/gdata-provider.xpi; (cd src && zip -9r ../dist/gdata-provider.xpi `git ls-files | grep -v 'package\\(-lock\\)\\?.json' | grep -v eslintrc`)",
     "clean": "rm -f dist/gdata-provider.xpi",
     "lint": "commitlint -f origin/main && eslint"
@@ -49,6 +49,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "conventional-changelog": "^6.0.0",
     "conventional-changelog-cli": "^5.0.0",
+    "cross-env": "^7.0.3",
     "eslint": "^9.22.0",
     "eslint-plugin-jest": "^28.11.0",
     "ical.js": "^2.1.0",

--- a/src/background/session.js
+++ b/src/background/session.js
@@ -267,6 +267,7 @@ class calGoogleSession {
         this.console.log("The client_id and client_secret are invalid, best upgrade to the latest Thunderbird/Provider");
         this.notifyOutdated();
         throw new TokenFailureError();
+      case "unauthorized_client":
       case "invalid_grant":
         this.console.log("The refresh token is invalid, need to start over with authentication");
         await this.invalidate();
@@ -277,7 +278,14 @@ class calGoogleSession {
           throw new TokenFailureError();
         }
         break;
+      case "invalid_request":
+      case "unsupported_grant_type":
+      case "invalid_scope":
+        this.console.error(`An unhandled OAuth2 failure occurred: '${reason}'. Upgrading to the latest Thunderbird/Provider might fix the issue.`);
+        this.notifyOutdated();
+        throw new TokenFailureError();
       default:
+        // should only happen when `reason === undefined` since all valid reasons have been covered above
         throw e;
     }
   }

--- a/test/jest/session.test.js
+++ b/test/jest/session.test.js
@@ -330,6 +330,99 @@ test("login", async () => {
   expect(messenger.gdata.setOAuthToken).toHaveBeenCalledWith("sessionId", "refreshToken");
 });
 
+
+const REQUEST_LOGIN = {
+  method: "POST",
+  url: "https://oauth2.googleapis.com/token",
+  headers: { "Content-Type": "application/x-www-form-urlencoded;charset=utf-8" },
+  body: {
+    client_secret: "test_secret",
+    client_id: "test_id",
+    code: "authCode",
+    grant_type: "authorization_code",
+    redirect_uri: "http://localhost/"
+  }
+};
+
+const REQUEST_REFRESH_TOKEN = {
+  method: "POST",
+  url: "https://oauth2.googleapis.com/token",
+  headers: { "Content-Type": "application/x-www-form-urlencoded;charset=utf-8" },
+  body: {
+    client_secret: "test_secret",
+    client_id: "test_id",
+    grant_type: "refresh_token",
+    refresh_token: "refreshToken"
+  }
+};
+
+const RESPONSE_LOGIN_SUCCESS = {
+  status: 200,
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    access_token: "1/fFAGRNJru1FTz70BzhT3Zg",
+    refresh_token: "refreshToken",
+    expires_in: 300,
+    scope: "https://www.googleapis.com/auth/calendar",
+    token_type: "Bearer"
+  }),
+};
+const RESPONSE_REFRESH_TOKEN_SUCCESS = {
+  status: 200,
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    access_token: "1/fFAGRNJru1FTz70BzhT3Zg",
+    expires_in: 300,
+    scope: "https://www.googleapis.com/auth/calendar",
+    token_type: "Bearer"
+  }),
+};
+
+const RESPONSE_INVALID_ACCESS_TOKEN = {
+  status: 401,
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    error: {
+      errors: [{
+        reason: "unauthorized_client"
+      }]
+    }
+  }),
+};
+const RESPONSE_INVALID_REFRESH_TOKEN = {
+  status: 400,
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    error: "invalid_grant",
+    error_description: "The refresh token is invalid"
+  }),
+};
+const RESPONSE_INVALID_CLIENT = {
+  status: 400,
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    error: "invalid_client",
+    error_description: "The OAuth client was not found"
+  }),
+};
+const RESPONSE_RATE_LIMIT = {
+  status: 400,
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    error: "userRateLimitExceeded",
+    error_description: "The OAuth client was not found"
+  }),
+};
+const RESPONSE_LOGIN_FAILED = {
+  status: 400,
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    error: "invalid_grant",
+    error_description: "Malformed auth code"
+  })
+};
+
+
 describe("login paths", () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -337,99 +430,6 @@ describe("login paths", () => {
   afterEach(() => {
     jest.useRealTimers();
   });
-
-  const REQUEST_LOGIN = {
-    method: "POST",
-    url: "https://oauth2.googleapis.com/token",
-    headers: { "Content-Type": "application/x-www-form-urlencoded;charset=utf-8" },
-    body: {
-      client_secret: "test_secret",
-      client_id: "test_id",
-      code: "authCode",
-      grant_type: "authorization_code",
-      redirect_uri: "http://localhost/"
-    }
-  };
-
-  const REQUEST_REFRESH_TOKEN = {
-    method: "POST",
-    url: "https://oauth2.googleapis.com/token",
-    headers: { "Content-Type": "application/x-www-form-urlencoded;charset=utf-8" },
-    body: {
-      client_secret: "test_secret",
-      client_id: "test_id",
-      grant_type: "refresh_token",
-      refresh_token: "refreshToken"
-    }
-  };
-
-  const RESPONSE_LOGIN_SUCCESS = {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      access_token: "1/fFAGRNJru1FTz70BzhT3Zg",
-      refresh_token: "refreshToken",
-      expires_in: 300,
-      scope: "https://www.googleapis.com/auth/calendar",
-      token_type: "Bearer"
-    }),
-  };
-  const RESPONSE_REFRESH_TOKEN_SUCCESS = {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      access_token: "1/fFAGRNJru1FTz70BzhT3Zg",
-      expires_in: 300,
-      scope: "https://www.googleapis.com/auth/calendar",
-      token_type: "Bearer"
-    }),
-  };
-
-  const RESPONSE_INVALID_ACCESS_TOKEN = {
-    status: 401,
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      error: {
-        errors: [{
-          reason: "unauthorized_client"
-        }]
-      }
-    }),
-  };
-  const RESPONSE_INVALID_REFRESH_TOKEN = {
-    status: 400,
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      error: "invalid_grant",
-      error_description: "The refresh token is invalid"
-    }),
-  };
-  const RESPONSE_INVALID_CLIENT = {
-    status: 400,
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      error: "invalid_client",
-      error_description: "The OAuth client was not found"
-    }),
-  };
-  const RESPONSE_RATE_LIMIT = {
-    status: 400,
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      error: "userRateLimitExceeded",
-      error_description: "The OAuth client was not found"
-    }),
-  };
-  const RESPONSE_LOGIN_FAILED = {
-    status: 400,
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      error: "invalid_grant",
-      error_description: "Malformed auth code"
-    })
-  };
-
-
   test("refresh expired access token", async () => {
     jest.setSystemTime(new Date("2024-01-01T00:00:00Z"));
     session.oauth.expires = new Date("2023-12-31T23:59:59Z");
@@ -1035,4 +1035,57 @@ test("invalidate", async () => {
 
   expect(session.oauth.invalidate).toHaveBeenCalled();
   expect(messenger.gdata.setOAuthToken).toHaveBeenCalledWith("sessionId", "refreshToken");
+});
+
+describe("refreshAccessToken", () => {
+  test.each(["unauthorized_client", "invalid_grant"])("attempts a refresh on '%s'", async (error) => {
+    let fetchMocks = new FetchMocks([
+      {
+        request: REQUEST_REFRESH_TOKEN,
+        response: {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            error,
+            error_description: "The refresh token is invalid"
+          }),
+        }
+      },
+    ]);
+
+    await messenger.gdata.setOAuthToken(session.id, "refreshToken");
+    session.oauth.login = jest.fn(async () => {});
+
+    await session.refreshAccessToken(true);
+
+    expect(session.oauth.login).toHaveBeenCalled();
+    fetchMocks.expectFetchCount();
+  });
+
+  test.each([
+    "invalid_request",
+    "unsupported_grant_type",
+    "invalid_scope"
+  ])("attempts no refresh on '%s'", async (error) => {
+    // These errors are likely unrecoverable. If this assumption is wrong, the code and test should be changed.
+    let fetchMocks = new FetchMocks([
+      {
+        request: REQUEST_REFRESH_TOKEN,
+        response: {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            error,
+            error_description: error
+          }),
+        }
+      },
+    ]);
+
+    await messenger.gdata.setOAuthToken(session.id, "refreshToken");
+    session.oauth.login = jest.fn(async () => {});
+
+    await expect(session.refreshAccessToken(true)).rejects.toThrow("TOKEN_FAILURE");
+    fetchMocks.expectFetchCount();
+  });
 });


### PR DESCRIPTION
As mentioned on https://github.com/kewisch/gdata-provider/discussions/875#discussioncomment-12592538, there is a bug when the refresh token is no longer valid (e.g. when the client registration has changed or the refresh token itself has expired).

This issue is fixed here by locally invalidating the existing refresh token in case we get a 401. This triggers a new login by the user, which is the expected behaviour. All other errors are thrown as exceptions like before.

As a small drive-by, I added `cross-env` so the tests can be run easily on Windows.