### PR TITLE
Fix for issue #905 (Problem with Outlook/Teams appointment emails : can't view ICS file and event options)

### DIFF
--- a/src/legacy/modules/gdataCalendar.sys.mjs
+++ b/src/legacy/modules/gdataCalendar.sys.mjs
@@ -339,7 +339,7 @@ export class calGoogleCalendar extends cal.provider.BaseClass {
       case "itip.transport":
         if (
           !this.isDefaultCalendar ||
-          !messenger.gdataSyncPrefs.get("settings.enableEmailInvitations", false)
+          !lazy.messenger.gdataSyncPrefs.get("settings.enableEmailInvitations", false)
         ) {
           // If we explicitly return null here, then these calendars
           // will not be included in the list of calendars to accept


### PR DESCRIPTION
Line 342 is the one causing the error "messenger is not defined" reported in issue #905.

I'm not such an expert in Thunderbird extension development, but I see that line 342 is the only one where `messenger` is called directly. Other references are done through `lazy.messenger` instead.

So my patch is a simple `messenger` --> `lazy.messenger` change.

Please validate it and check if I'm missing something.

Keep up the good work 👍