### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ These are the sources for the [Provider for Google Calendar](https://addons.thun
 Development
 -----------
 
-The Provider for Google Calendar is written as a WebExtension, which means most code is very familiar to (vanilla)
+The Provider for Google Calendar is written as a WebExtension, which means most of the code is very familiar to (vanilla)
 website development with a few additional APIs to call.
 
-Additionally, it uses an experiment API to provide calendaring functionality which hopefully will
+Additionally, it uses an experimental API to provide calendaring functionality which hopefully will
 become part of Thunderbird. Ideally you do not have to touch anything in the `src/experiments/` or `src/legacy/`
 directories. If you do need to touch `src/experiments/calendar`, then please send a pull request to
 https://github.com/thunderbird/webext-experiments in addition.
@@ -51,7 +51,7 @@ First of all, make sure you are using the latest version of the Provider for Goo
 
 For debugging, please enable calendar.debug.log and calendar.debug.log.verbose in the advanced
 config editor (`Options > Advanced > General > Config Editor`) and check the logs in the error console
-(`Tools > Error Console`) for what is happening when your error occurs.
+(`Tools > Error Console`) to see what is happening when your error occurs.
 
 Please check the [FAQ](https://github.com/kewisch/gdata-provider/wiki/FAQ) to see if your question may already be
 answered. If you have a support question, please visit

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Development
 The Provider for Google Calendar is written as a WebExtension, which means most code is very familiar to (vanilla)
 website development with a few additional APIs to call.
 
-Additionally, it uses an experiment API to provider calendaring functionality which hopefully will
-become part of Thunderbird. Ideally yo do not have to touch anything in the `src/experiments/` or `src/legacy/`
-directory. If you do need to touch `src/experiments/calendar`, then please send a pull request to
+Additionally, it uses an experiment API to provide calendaring functionality which hopefully will
+become part of Thunderbird. Ideally you do not have to touch anything in the `src/experiments/` or `src/legacy/`
+directories. If you do need to touch `src/experiments/calendar`, then please send a pull request to
 https://github.com/thunderbird/webext-experiments in addition.
 
-Test are written with jest and use a custom mock for the WebExtensions API.
+Tests are written with jest and use a custom mock for the WebExtensions API.
 
 ```bash
 $ npm run test
@@ -47,7 +47,7 @@ https://weblate.org/
 
 Report Issues
 -------------
-First of all, make sure you are the latest version of the Provider for Google Calendar.
+First of all, make sure you are using the latest version of the Provider for Google Calendar.
 
 For debugging, please enable calendar.debug.log and calendar.debug.log.verbose in the advanced
 config editor (`Options > Advanced > General > Config Editor`) and check the logs in the error console


### PR DESCRIPTION
- 'Fix typos' commit fixes mistakes.
- 'Fix grammar' commit contains what I believe to be improvements. Please check the edits to see if you agree with them.