### PR TITLE
fix: Include new fromGmail event type

### DIFF
--- a/src/background/utils.js
+++ b/src/background/utils.js
@@ -11,7 +11,7 @@ const EMAIL_REGEX = /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|
 
 export const GCAL_PATH_RE = /\/calendar\/(feeds|ical)\/([^/]+)\/(public|private|free-busy)-?([^/]+)?\/(full|basic)(.ics)?$/;
 
-export const DEFAULT_EVENT_TYPES = ["default", "focusTime", "outOfOffice"];
+export const DEFAULT_EVENT_TYPES = ["default", "focusTime", "outOfOffice", "fromGmail"];
 
 export const NOTIFY_TIMEOUT = 60000;
 

--- a/src/legacy/modules/old/gdataCalendar.sys.mjs
+++ b/src/legacy/modules/old/gdataCalendar.sys.mjs
@@ -827,7 +827,7 @@ export class calGoogleCalendar extends cal.provider.BaseClass {
     eventsRequest.type = eventsRequest.GET;
     eventsRequest.uri = this.createEventsURI("events");
     eventsRequest.addQueryParameter("maxResults", maxResults);
-    eventsRequest.addQueryParameter("eventTypes", ["default", "focusTime", "outOfOffice"]);
+    eventsRequest.addQueryParameter("eventTypes", ["default", "focusTime", "outOfOffice", "fromGmail"]);
     let syncToken = this.getProperty("syncToken.events");
     if (syncToken) {
       eventsRequest.addQueryParameter("showDeleted", "true");


### PR DESCRIPTION
The event type for automatically generated calendar events was changed from `default` to `fromGmail`, meaning they were no longer included: https://workspaceupdates.googleblog.com/2024/05/google-calendar-api-event-type-fromgmail.html. This restores the previous behavior.

Fixes #868.